### PR TITLE
Add Travis and AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,24 @@
+environment:
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      VCVARS_FILE: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+      VCVARS_ARG: x86
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      VCVARS_FILE: C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat
+      VCVARS_ARG: x86_amd64
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      VCVARS_FILE: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat
+      VCVARS_ARG:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      VCVARS_FILE: C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars64.bat
+      VCVARS_ARG:
+
+install:
+  - call "%VCVARS_FILE%" %VCVARS_ARG%
+
+build_script:
+  - mkdir build
+  - cd build
+  - cmake .. -G "NMake Makefiles"
+  - nmake
+  - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,57 @@
+language: cpp
+
+matrix:
+  include:
+    - os: osx
+      osx_image: xcode8
+    - os: osx
+      osx_image: xcode9
+    - os: linux
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+      env:
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-6
+      env:
+        - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-7
+      env:
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+before_install:
+  - eval "${MATRIX_EVAL}"
+
+before_script:
+  - mkdir build
+  - cd build
+  - cmake .. -DCMAKE_BUILD_TYPE=Debug
+
+script:
+  - make
+  - ctest --output-on-failure

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # array
 
+[![Build Status](https://travis-ci.org/dacap/array.svg)](https://travis-ci.org/dacap/array)
+[![Build Status](https://ci.appveyor.com/api/projects/status/8so5vnnk5tod0xbk?svg=true)](https://ci.appveyor.com/project/dacap/array)
+[![Boost Licensed](https://img.shields.io/badge/license-Boost-blue.svg)](LICENSE)
+
 > Note: This project is currently WIP, no guarantees are made until an 0.1 release.
 
 This library is all about *arrays* — contiguous blocks of memory.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # array
 
-[![Build Status](https://travis-ci.org/dacap/array.svg)](https://travis-ci.org/dacap/array)
-[![Build Status](https://ci.appveyor.com/api/projects/status/8so5vnnk5tod0xbk?svg=true)](https://ci.appveyor.com/project/dacap/array)
+[![Build Status](https://travis-ci.org/foonathan/array.svg)](https://travis-ci.org/foonathan/array)
+[![Build status](https://ci.appveyor.com/api/projects/status/iydnaute3tiqxi9u?svg=true)](https://ci.appveyor.com/project/foonathan/array)
 [![Boost Licensed](https://img.shields.io/badge/license-Boost-blue.svg)](LICENSE)
 
 > Note: This project is currently WIP, no guarantees are made until an 0.1 release.


### PR DESCRIPTION
Hi @foonathan, this is just a little help to add Travis and AppVeyor CIs.

Anyway the build has failed, so you might like to look to this:

* https://travis-ci.org/dacap/array
* https://ci.appveyor.com/project/dacap/array

You can merge this PR or just copy and paste whatever you find useful for your project, or just ignore it.

P.S. You'll need to adjust the README.md links (replacing "dacap" with "foonathan") and enable this project in both websites.