### PR TITLE
Avoid undefined behavior when calling memcpy on empty source range.

### DIFF
--- a/include/foonathan/array/raw_storage.hpp
+++ b/include/foonathan/array/raw_storage.hpp
@@ -272,9 +272,9 @@ namespace foonathan
                     auto block_begin_ptr = to_void_pointer(block.begin());
                     assert(block_begin_ptr != nullptr);
                     std::memcpy(block_begin_ptr, source_begin_ptr, size);
-                } else {
-                    assert(no_elements == 0);
                 }
+                else
+                    assert(no_elements == 0);
                 return block.begin() + size;
             }
 

--- a/include/foonathan/array/raw_storage.hpp
+++ b/include/foonathan/array/raw_storage.hpp
@@ -266,7 +266,15 @@ namespace foonathan
                 auto no_elements = std::size_t(end - begin);
                 auto size        = no_elements * sizeof(T);
                 assert(block.size() >= size);
-                std::memcpy(to_void_pointer(block.begin()), iterator_to_pointer(begin), size);
+                auto source_begin_ptr = iterator_to_pointer(begin);
+                if (source_begin_ptr != nullptr)
+                {
+                    auto block_begin_ptr = to_void_pointer(block.begin());
+                    assert(block_begin_ptr != nullptr);
+                    std::memcpy(block_begin_ptr, source_begin_ptr, size);
+                } else {
+                    assert(no_elements == 0);
+                }
                 return block.begin() + size;
             }
 


### PR DESCRIPTION
When an array/bag/... with `block_storage_heap` as internal storage is default constructed, the `block_storage_heap`'s `memory_block` contains two null pointers.

When the first element is inserted in these containers, they must be resized, since their capacity is zero. Part of increasing the capacity is copying/moving all existing data to the new storage location. If this causes a call to `uninitialized_move_copy_impl(std::true_type, ...)`, there's undefined behavior.

The reason is that the source's begin and end iterators passed to `uninitialized_move_copy_impl` are both nullptr on this first capacity increase. Inside this function a call `std::memcpy(..., iterator_to_pointer(begin), ...)` is made. In this case, `begin == nullptr`, so the 2nd argument is a nullptr. Which is undefined behavior, even if the size argument (3rd one) is zero (which is the case here, since `begin - end == nullptr - nullptr == 0`).

As mentioned [here](https://stackoverflow.com/a/5243068), the undefined behavior is due to the C standard (ISO/IEC 9899:1999) §7.21.1/2. I can't find the same wording in the [C++17 draft standard (N4659)](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2017/n4659.pdf), but it does note in §24.5.3: 
> The contents and meaning of the header \<cstring\> are the same as the C standard library header <string.h>.

So I'm assuming the same rules apply.

GCC 9.1.0's undefined behavior sanitizer seems to think so as well, since it aborts execution when `std::memcpy` is called in such a way.

This little patch fixes the issue. I am assuming the destination is never a nullptr, hence the assert instead of making that check part of the if-clause.